### PR TITLE
Enable https if we are being proxied

### DIFF
--- a/app/webroot/index.php
+++ b/app/webroot/index.php
@@ -18,6 +18,15 @@
  * @since         CakePHP(tm) v 0.2.9
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
+
+/**
+ * If we are behind a front-end proxy like Nginx or Varnish, enable HTTPS if the forwarded 
+ * protocol is https.
+ */
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+    $_SERVER['HTTPS'] = 'on';
+}
+
 /**
  * Use the DS to separate the directories in other defines
  */


### PR DESCRIPTION
A front-end load balancer like Nginx will send the X-Forwarded-Proto to tell the app server that the request is occurring over https.  

http://tools.ietf.org/html/draft-ietf-appsawg-http-forwarded-10
