### PR TITLE
Certificates: Allow '-' in supplied email address.

### DIFF
--- a/app/Controller/TutorialsController.php
+++ b/app/Controller/TutorialsController.php
@@ -973,7 +973,10 @@ class TutorialsController extends AppController {
           if (!empty($to_string)) {
             $to_string .= ',';
           }
-          $to_string .= Sanitize::paranoid($this->request->data['certificate_email'], array('@', '.', ',', '+'));
+          $to_string .= Sanitize::paranoid(
+              $this->request->data['certificate_email'],
+              array('@', '.', ',', '+', '-')
+          );
         }
         
         $this->set('date', date('F j, Y'));


### PR DESCRIPTION
Hi Michael, Ginger

Please find the patch implementing the change to certificate email send submission I suggested in the Google Groups discussion.
- app/Controller/TutorialsController.php (view_certificate): add '-' to
  sanitize exceptions array.
