### PR TITLE
Piwik: add option to collect statistics with Piwik

### DIFF
--- a/app/Config/bootstrap.php
+++ b/app/Config/bootstrap.php
@@ -112,3 +112,4 @@ App::build(array('View' => array(ROOT . DS . 'themes' . DS)));
 //  $revision_message = Configure::read('user_config.require_revision_message'); 
   Configure::write('require_revision_message', false);
   Configure::write('GoogleAnalytics.enabled', Configure::read('user_config.google_analytics.enabled'));
+  Configure::write('PiwikAnalytics.enabled', Configure::read('user_config.piwik_analytics.enabled'));

--- a/app/View/Elements/google_analytics.ctp
+++ b/app/View/Elements/google_analytics.ctp
@@ -8,4 +8,24 @@
    pageTracker._setDomainName("<?php echo Configure::read('user_config.google_analytics.domain_name') ?>");
    pageTracker._trackPageview();
 </script>
+<?php elseif (Configure::read('PiwikAnalytics.enabled') && !isset($noGoogleAnalytics)): ?>
+<!-- Piwik -->
+<script type="text/javascript">
+  var _paq = _paq || [];
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u=(("https:" == document.location.protocol) ? "https" : "http") + "://<?php echo Configure::read('user_config.piwik_analytics.piwik_server') ?>/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', <?php echo Configure::read('user_config.piwik_analytics.site_id') ?>]);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript';
+    g.defer=true; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript>
+  <p>
+    <img src="http://<?php echo Configure::read('user_config.piwik_analytics.piwik_server') ?>/piwik.php?idsite=<?php echo Configure::read('user_config.piwik_analytics.site_id') ?>" style="border:0;" alt="" />
+  </p>
+</noscript>
+<!-- End Piwik Code -->
 <?php endif ?>

--- a/app/config.sample.yml
+++ b/app/config.sample.yml
@@ -13,6 +13,11 @@ google_analytics:
   account_id: UA-something
   domain_name: your-domain-name.edu
 
+piwik_analytics:
+  enabled: false
+  piwik_server: piwik.server.com # Your Piwik server address (now leading http:///https://)
+  site_id: 99                    # Number provided by Piwik
+
 authentication:
   # local or shibboleth
   method: local


### PR DESCRIPTION
Hi Michael,

Please find a patch below which should allow Piwik (http://piwik.org/) stats users to edit config.yaml to enable Piwik data collection similar to Google Analytics configuration.

Not 100% sure on whether I edited the correct config.sample.yml — let me know if it isn't.

Best wishes,

Alex
- app/Config/bootstrap.php: Configure::write for PiwikAnalytics.
- app/View/Elements/google_analytics.ctp: extend if to include Piwik branch.
- app/config.sample.yml: add Piwik sample configuration.
