### PR TITLE
Set a default timezone

### DIFF
--- a/app/Config/core.php
+++ b/app/Config/core.php
@@ -229,7 +229,10 @@
  * Uncomment this line and correct your server timezone to fix 
  * any date & time related errors.
  */
-	//date_default_timezone_set('UTC');
+if (!ini_get('date.timezone')) {
+	// Set the default timezone to UTC if it was not set via php.ini
+	date_default_timezone_set('UTC');
+}
 
 /**
  * Pick the caching engine to use.  If APC is enabled use it.


### PR DESCRIPTION
Fixes #97

As described in issue 97, GotS encountered errors serving assets because I didn't have a timezone set in my local PHP setup.  (CakePHP was attempting to send the Last-Modified header for the file).

This is fixed by calling date_default_timezone_set('UTC') in app/Config/core.php if date.timezone is not set via the PHP ini.

I refrained from adding a configuration option since I think most people can get it configured via their PHP settings.  If you would like the configuration option for timezone, I can include this commit: https://github.com/ndlib/Guide-on-the-Side/commit/74a910d45c5f95f6e54d790636e2c8022b478177