### PR TITLE
Fix next arrow aliasing issue on Firefox

### DIFF
--- a/app/webroot/css/tutorials/view_tutorial_only.css
+++ b/app/webroot/css/tutorials/view_tutorial_only.css
@@ -83,6 +83,7 @@ a:active {
   top: 50%;
   margin-top: -12px;
   border: solid 12px #585858;
+  border-style: dotted solid;
 }
 #navigation a.prev:before{
   right: 100%;


### PR DESCRIPTION
Removes the jaggies on the **Next** arrow that can show up in Firefox. (Reference: https://brettstrikesback.com/de-pixelating-the-css-triangle/)

Before applying this commit:
![aliased](https://cloud.githubusercontent.com/assets/1648347/9804870/376e6a60-5800-11e5-9dcd-d1d236cd107a.PNG)

After applying this commit:
![antialiased](https://cloud.githubusercontent.com/assets/1648347/9804878/596006c4-5800-11e5-8de4-0a9490a2f6f5.PNG)
